### PR TITLE
[BUGFIX] Reintroduce class attribute support for form elements

### DIFF
--- a/src/Resources/overrides/TwigBundle/Form/custom_theme.html.twig
+++ b/src/Resources/overrides/TwigBundle/Form/custom_theme.html.twig
@@ -83,14 +83,16 @@
 
 {% block radio_widget -%}
     <div class="form-check">
-        <input class="form-check-input" type="radio" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-check-input')|trim}) -%}
+        <input type="radio" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
         {{- form_label(form, null, { widget: true }) -}}
     </div>
 {%- endblock radio_widget %}
 
 {% block checkbox_widget -%}
     <div class="form-check">
-        <input class="form-check-input" type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-check-input')|trim}) -%}
+        <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
         {{- form_label(form, null, { widget: true }) -}}
     </div>
 {%- endblock checkbox_widget %}


### PR DESCRIPTION
This feature was removed with the 3.x releases and breaks the Composer Helper at get.typo3.org.